### PR TITLE
fix: pass application context to adapter setup

### DIFF
--- a/cmd/receive_adapter/main.go
+++ b/cmd/receive_adapter/main.go
@@ -16,9 +16,13 @@ package main
 
 import (
 	"knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/signals"
 	myadapter "knative.dev/sample-source/pkg/adapter"
 )
 
 func main() {
-	adapter.Main("sample-source", myadapter.NewEnv, myadapter.NewAdapter)
+	ctx := signals.NewContext()
+	ctx = adapter.WithInjectorEnabled(ctx)
+
+	adapter.MainWithContext(ctx, "sample-source", myadapter.NewEnv, myadapter.NewAdapter)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes the receive adapter context to start without panic
