### PR TITLE
Migrate golanglint-ci config to v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,15 +1,28 @@
+version: "2"
 run:
-  timeout: 5m
-
   build-tags:
     - e2e
-
-  skip-dirs:
-    - pkg/client
-
 linters:
   enable:
-    - unconvert
     - prealloc
+    - unconvert
   disable:
     - errcheck
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
As per title to prevent https://github.com/knative-extensions/sample-source/actions/runs/14435702914/job/40476342335?pr=661